### PR TITLE
Release/0.0.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,18 @@ repos:
     hooks:
       - id: build-docs
         language_version: python3
+
+  - repo: https://github.com/windpioneers/pre-commit-hooks
+    rev: 0.0.5
+    hooks:
+      - id: check-branch-name
+        args:
+          - '^master$'
+          - '^dev$'
+          - '^devops/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
+          - '^doc/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
+          - '^feature/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
+          - '^fix/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
+          - '^hotfix/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
+          - '^review/([a-z][a-z0-9]*)(-[a-z0-9]+)*$'
+          - '^release/(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,11 +1,9 @@
  [requires]
  eigen/3.3.7
  nlohmann_json/3.8.0
- cpr/1.5.0
  boost/1.73.0
  glog/0.4.0
  gtest/1.10.0
  tbb/2020.1
-
  [generators]
  cmake

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -85,7 +85,7 @@ importable there, since it's compliant with their schema.
 
 I'm not a marketing person for plotly, so how to do that is out of scope here (check their docs)!!
 
-I have a branch that has some code using the Plotly API,
+I have some code using the Plotly API (`see online.h <https://github.com/thclark/cpplot/blob/458d26f99aa4298e7260bb5da65ba7915f098f5f/source/online.h#L160>`__ ),
 which might be the very early beginning of a client SDK for C++,
 enabling direct manipulation of online data. However, I have very little
 appetite for this (I personally don't use plotly online, because I've

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -29,7 +29,7 @@ all the tricky dependencies.
 .. code:: bash
 
     git clone https://github.com/thclark/cpplot
-    cd cpplot && cmake . -B build
+    cd cpplot && mkdir -p build && cmake . -B build
 
 This process will die first time around, and you'll get a message like:
 

--- a/docs/source/version_history.rst
+++ b/docs/source/version_history.rst
@@ -118,3 +118,4 @@ Bug Fixes & Minor Changes
 -------------------------
 #. Removed unused cpr dependency from build system
 #. Updated docs to reflect the removed dep and to close #17
+#. Added a branch naming rule to the git pre-commit

--- a/docs/source/version_history.rst
+++ b/docs/source/version_history.rst
@@ -99,3 +99,22 @@ Bug Fixes & Minor Changes
 -------------------------
 #. Fix for building against glog on windows
 #. Corrected build instructions in documentation
+
+
+0.0.4
+=====
+
+Removed unused cpr dependency from build system
+
+New Features
+------------
+#. n/a
+
+Backward Incompatible API Changes
+---------------------------------
+#. n/a
+
+Bug Fixes & Minor Changes
+-------------------------
+#. Removed unused cpr dependency from build system
+#. Updated docs to reflect the removed dep and to close #17


### PR DESCRIPTION
- Removed unused cpr dependency from build system
- Updated docs to reflect the removed dependency and to close #17
- Added branch naming rules to pre-commit